### PR TITLE
Update tester from master

### DIFF
--- a/src/iscsi.pyx
+++ b/src/iscsi.pyx
@@ -4,8 +4,8 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from libc.stdlib cimport calloc
 from cpython.bytes cimport PyBytes_FromStringAndSize
+from libc.stdlib cimport calloc
 
 
 cdef extern from "iscsi/scsi-lowlevel.h":
@@ -62,11 +62,22 @@ cdef extern from "iscsi/iscsi.h":
     cdef struct iscsi_data:
         pass
 
+    cdef struct iscsi_target_portal:
+        iscsi_target_portal *next
+        char *portal
+
+    cdef struct iscsi_discovery_address:
+        iscsi_discovery_address *next
+        char *target_name
+        iscsi_target_portal *portals
+
     cdef iscsi_context *iscsi_create_context(const char *initiator_name)
     cdef iscsi_url *iscsi_parse_full_url(iscsi_context *iscsi, const char* url)
     cdef int iscsi_set_targetname(iscsi_context *iscsi, const char *targetname)
     cdef int iscsi_set_session_type(iscsi_context *iscsi, iscsi_session_type session_type)
     cdef int iscsi_set_header_digest(iscsi_context *iscsi, iscsi_header_digest header_digest)
+    cdef int iscsi_set_initiator_username_pwd(iscsi_context *iscsi, const char *user, const char *passwd)
+    cdef int iscsi_set_target_username_pwd(iscsi_context *iscsi, const char *user, const char *passwd)
     cdef int iscsi_full_connect_sync(iscsi_context *iscsi, const char *portal, int lun)
     cdef int iscsi_disconnect(iscsi_context *iscsi)
 
@@ -77,6 +88,8 @@ cdef extern from "iscsi/iscsi.h":
         iscsi_context *iscsi, int lun, scsi_task *task, iscsi_data *data)
     cdef int scsi_task_get_status(scsi_task *task, scsi_sense *sense)
 
+    cdef iscsi_discovery_address *iscsi_discovery_sync(iscsi_context *iscsi)
+    cdef void iscsi_free_discovery_data(iscsi_context *iscsi, iscsi_discovery_address *da)
 
 cdef class Task:
     cdef scsi_task *_task
@@ -118,6 +131,14 @@ cdef class Context:
         if iscsi_set_header_digest(self._ctx, header_digest) < 0:
             raise ValueError("Invalid header digest: %s" % header_digest)
 
+    def set_initiator_username_pwd(self, str user, str passwd):
+        if iscsi_set_initiator_username_pwd(self._ctx, user.encode('utf-8'), passwd.encode('utf-8')) < 0:
+            raise ValueError("Invalid initiator user/pass: %s" % user)
+
+    def set_target_username_pwd(self, str user, str passwd):
+        if iscsi_set_target_username_pwd(self._ctx, user.encode('utf-8'), passwd.encode('utf-8')) < 0:
+            raise ValueError("Invalid target user/pass: %s" % user)
+
     def connect(self, str portal, int lun):
         if iscsi_full_connect_sync(self._ctx, portal.encode('utf-8'), lun) < 0:
             raise RuntimeError("Unable to connect to %s" % portal)
@@ -140,6 +161,20 @@ cdef class Context:
 
         iscsi_scsi_command_sync(self._ctx, lun, task._task, NULL)
 
+    def discover(self):
+        _da = iscsi_discovery_sync(self._ctx)
+        result = {}
+        da = _da
+        while da:
+            portals = []
+            dp = da.portals
+            while dp:
+                portals.append(dp.portal.decode('utf-8'))
+                dp = dp.next
+            result[da.target_name.decode('utf-8')] = portals
+            da = da.next
+        iscsi_free_discovery_data(self._ctx, _da)
+        return result
 
 cdef class URL:
     cdef iscsi_url *_url

--- a/src/iscsi.pyx
+++ b/src/iscsi.pyx
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 from libc.stdlib cimport calloc
+from cpython.bytes cimport PyBytes_FromStringAndSize
 
 
 cdef extern from "iscsi/scsi-lowlevel.h":
@@ -13,8 +14,12 @@ cdef extern from "iscsi/scsi-lowlevel.h":
         SCSI_XFER_READ
         SCSI_XFER_WRITE
 
+    cdef struct scsi_data:
+        int size
+        char *data
+
     cdef struct scsi_task:
-        pass
+        scsi_data datain
 
     cdef struct scsi_sense:
         pass
@@ -89,6 +94,9 @@ cdef class Task:
     def status(self):
         return scsi_task_get_status(self._task, NULL)
 
+    @property
+    def raw_sense(self):
+        return PyBytes_FromStringAndSize(&self._task.datain.data[2], self._task.datain.size-2)
 
 cdef class Context:
     cdef iscsi_context *_ctx


### PR DESCRIPTION
Rebase `tester` branch on `master`, which was recently updated from upstream.  (One of the upstream commits had previously been cherry-picked into `tester`, so doesn't appear in the files changed.)

This is being done so that we can available of the iscsi discovery code that has been merged upstream.

A CI run has been performed with this branch [here](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1719/).  [log](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/1719/console) shows:
```
Collecting cython-iscsi@ git+https://github.com/truenas/cython-iscsi.git@update_tester_from_master
```
and all of the `api2/test_261_iscsi_cmd.py` test PASSED (as did _api2/test_262_iscsi_alua.py_).  These are the ones that use `cython-scsi`.

----
```
git clone https://github.com/truenas/cython-iscsi.git
cd cython-iscsi/
git checkout tester
git checkout -b update_tester_from_master
git rebase master
```
